### PR TITLE
Refactor Archive.writeFile() to support readable streams

### DIFF
--- a/lib/Archive.js
+++ b/lib/Archive.js
@@ -616,10 +616,11 @@ function Archive(archiveConfigurator) {
             }
 
             function __createBricksRecursively(blockIndex, callback) {
-                const blockData = data.slice(blockIndex * _blockSize, (blockIndex + 1) * _blockSize - 1);
+                const blockData = data.slice(blockIndex * _blockSize, (blockIndex + 1) * _blockSize);
 
                 archiveConfigurator.setIsEncrypted(areEncrypted);
                 const brick = new Brick(archiveConfigurator);
+
                 brick.setRawData(blockData);
                 barMap.add(barPath, brick);
                 storageProvider.putBrick(brick, (err) => {

--- a/lib/Archive.js
+++ b/lib/Archive.js
@@ -69,33 +69,25 @@ function Archive(archiveConfigurator) {
         loadBarMapThenExecute(__addData, callback);
 
         function __addData() {
-            archiveConfigurator.setIsEncrypted(options.encrypt);
-            const brick = new Brick(archiveConfigurator);
             if (typeof data === "string") {
                 data = Buffer.from(data);
             }
 
-            if (!Buffer.isBuffer(data)) {
-                return callback(Error(`Type of data is ${typeof data}. Expected Buffer.`));
+            if (!isStream.isReadable(data) && !Buffer.isBuffer(data)) {
+                return callback(Error(`Type of data is ${typeof data}. Expected Buffer or Stream.Readable`));
             }
 
-            brick.setRawData(data);
-            if (!barMap.isEmpty(fileBarPath)) {
-                barMap.emptyList(fileBarPath);
-            }
-            barMap.add(fileBarPath, brick);
-            storageProvider.putBrick(brick, (err) => {
+            createBricksFromData(data, fileBarPath, archiveConfigurator.getBufferSize(), options.encrypt, (err) => {
                 if (err) {
                     return callback(err);
                 }
 
-                storageProvider.putBarMap(barMap, (err, digest) => {
-                    if (err) {
-                        return callback(err);
-                    }
+                barMap.setConfig(archiveConfigurator);
+                if (archiveConfigurator.getMapEncryptionKey()) {
+                    barMap.setEncryptionKey(archiveConfigurator.getMapEncryptionKey());
+                }
 
-                    callback(undefined, digest);
-                });
+                storageProvider.putBarMap(barMap, callback);
             });
         }
     };
@@ -582,6 +574,99 @@ function Archive(archiveConfigurator) {
                 });
             }
         });
+    }
+
+    /**
+     * Create bricks from a Buffer or a readable stream
+     * @param {Buffer|stream.Readable} data
+     * @param {string} barPath
+     * @param {number} blockSize
+     * @param {boolean} areEncrypted
+     * @param {callback} callback
+     */
+    function createBricksFromData(data, barPath, blockSize, areEncrypted, callback) {
+        if (typeof areEncrypted === "function") {
+            callback = areEncrypted;
+            areEncrypted = true;
+        }
+
+        if (typeof data === 'string') {
+            data = Buffer.from(data);
+        }
+
+        if (!barMap.isEmpty(barPath)) {
+            barMap.emptyList(barPath);
+        }
+
+        /**
+         * Break the Buffer into bricks
+         * @param {Buffer} data
+         * @param {number} _blockSize
+         * @param {callback} callback
+         */
+        function __createBricksFromBuffer(data, _blockSize, callback) {
+            if (typeof _blockSize === 'function') {
+                callback = _blockSize;
+                _blockSize = blockSize; // set the default blockSize
+            }
+
+            let noBlocks = Math.floor(data.length / _blockSize);
+            if ((data.length % _blockSize) > 0) {
+                ++noBlocks;
+            }
+
+            function __createBricksRecursively(blockIndex, callback) {
+                const blockData = data.slice(blockIndex * _blockSize, (blockIndex + 1) * _blockSize - 1);
+
+                archiveConfigurator.setIsEncrypted(areEncrypted);
+                const brick = new Brick(archiveConfigurator);
+                brick.setRawData(blockData);
+                barMap.add(barPath, brick);
+                storageProvider.putBrick(brick, (err) => {
+                    if (err) {
+                        return callback(err);
+                    }
+
+                    ++blockIndex;
+                    if (blockIndex < noBlocks) {
+                        __createBricksRecursively(blockIndex, callback);
+                    } else {
+                        callback();
+                    }
+                });
+
+            }
+
+            __createBricksRecursively(0, callback);
+        }
+
+        if (isStream.isReadable(data)) {
+            data.on('data', (chunk) => {
+                if (typeof chunk === 'string') {
+                    chunk = Buffer.from(chunk);
+                }
+                data.pause();
+
+                // When reading from a stream, set the block size to the chunk's length
+                __createBricksFromBuffer(chunk, chunk.length, (err) => {
+                    if (err) {
+                        data.destroy(err);
+                        return callback(err);
+                    }
+                    data.resume();
+                });
+            });
+            data.on('error', (err) => {
+                callback(err);
+            });
+            data.on('end', () => {
+                callback();
+            });
+        } else { // Data is buffer
+            __createBricksFromBuffer(data, (err) => {
+                callback(err);
+            });
+        }
     }
 
     function loadBarMapThenExecute(functionToBeExecuted, callback) {


### PR DESCRIPTION
Support reading from readable stream.
Changed implementation to create multiple bricks from buffer or stream.
Implementation was based on the Archive.addFile() method.