### PR TITLE
Fix race condition during batch anchoring

### DIFF
--- a/lib/Archive.js
+++ b/lib/Archive.js
@@ -21,6 +21,8 @@ function Archive(archiveConfigurator) {
     let brickStorageService;
     let manifestHandler;
     let batchOperationsInProgress = false;
+    let batchCommitInProgress = false;
+    let batchCommitPromise = Promise.resolve();
     let prevAnchoringDecisionFn;
     let prevConflictResolutionFunction;
 
@@ -120,7 +122,24 @@ function Archive(archiveConfigurator) {
 
         commitBatch(mountedArchivesForBatchOperations.pop());
     }
-
+    
+    /**
+     * This function waits for a batch of operations
+     * to finish anchoring before executing the `callback`.
+     * If no anchoring is in progress, the `callback` is executed
+     * immediately.
+     * This function is called by the public methods in order to prevent
+     * race conditions when mixing batch & non-batch anchoring operations
+     *
+     * @param {function} callback 
+     */
+    const whenSafe = (callback) => {
+        if (batchCommitInProgress === false) {
+            return callback();
+        }
+        
+    }
+    
     const getArchiveForBatchOperations = (manifestHandler, path, callback) => {
         manifestHandler.getArchiveForPath(path, (err, result) => {
             if (err) {
@@ -254,7 +273,14 @@ function Archive(archiveConfigurator) {
      *
      * @return {HashLinkSSI}
      */
-    this.getCurrentAnchoredHashLink = () => {
+    this.getCurrentAnchoredHashLink = (callback) => {
+        if (typeof callback === 'function') {
+            return whenSafe(() => {
+                return callback(undefined, brickMapController.getCurrentAnchoredHashLink());
+            })
+        }
+        
+        // console.trace("This function behaviour changed to async. Pass a callback to obtain the result. The sync version of this method can throw an exception if called while batch anchoring is in the commit phase.");
         return brickMapController.getCurrentAnchoredHashLink();
     }
 
@@ -424,27 +450,29 @@ function Archive(archiveConfigurator) {
     };
 
     this.addFiles = (files, barPath, options, callback) => {
-        if (typeof options === "function") {
-            callback = options;
-            options = {
-                encrypt: true,
-                ignoreMounts: false,
-                embedded: false
-            };
-        }
+        whenSafe(() => {
+            if (typeof options === "function") {
+                callback = options;
+                options = {
+                    encrypt: true,
+                    ignoreMounts: false,
+                    embedded: false
+                };
+            }
 
-        if (options.ignoreMounts === true) {
-            _addFiles(files, barPath, options, callback);
-        } else {
-            this.getArchiveForPath(barPath, (err, dossierContext) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${barPath}`, err));
-                }
+            if (options.ignoreMounts === true) {
+                _addFiles(files, barPath, options, callback);
+            } else {
+                this.getArchiveForPath(barPath, (err, dossierContext) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${barPath}`, err));
+                    }
 
-                options.ignoreMounts = true;
-                dossierContext.archive.addFiles(files, dossierContext.relativePath, options, callback);
-            });
-        }
+                    options.ignoreMounts = true;
+                    dossierContext.archive.addFiles(files, dossierContext.relativePath, options, callback);
+                });
+            }
+        })
     }
 
     /**
@@ -476,42 +504,46 @@ function Archive(archiveConfigurator) {
      * @param {callback} callback
      */
     this.appendToFile = (barPath, data, options, callback) => {
-        const defaultOpts = {encrypt: true, ignoreMounts: false};
-        if (typeof options === "function") {
-            callback = options;
-            options = {};
-        }
+        whenSafe(() => {
+            const defaultOpts = { encrypt: true, ignoreMounts: false };
+            if (typeof options === "function") {
+                callback = options;
+                options = {};
+            }
 
-        Object.assign(defaultOpts, options);
-        options = defaultOpts;
+            Object.assign(defaultOpts, options);
+            options = defaultOpts;
 
-        if (options.ignoreMounts) {
-            barPath = pskPth.normalize(barPath);
-            brickStorageService.ingestData(data, options, (err, result) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Failed to append data to file " + barPath, err));
-                }
+            if (options.ignoreMounts) {
+                barPath = pskPth.normalize(barPath);
+                brickStorageService.ingestData(data, options, (err, result) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Failed to append data to file " + barPath, err));
+                    }
 
-                brickMapController.appendToFile(barPath, result, callback);
-            });
-        } else {
-            this.getArchiveForPath(barPath, (err, dossierContext) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${barPath}`, err));
-                }
-                if (dossierContext.readonly === true) {
-                    return callback(Error("Tried to write in a readonly mounted RawDossier"));
-                }
+                    brickMapController.appendToFile(barPath, result, callback);
+                });
+            } else {
+                this.getArchiveForPath(barPath, (err, dossierContext) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${barPath}`, err));
+                    }
+                    if (dossierContext.readonly === true) {
+                        return callback(Error("Tried to write in a readonly mounted RawDossier"));
+                    }
 
-                options.ignoreMounts = true;
-                dossierContext.archive.appendToFile(dossierContext.relativePath, data, options, callback);
-            });
-        }
+                    options.ignoreMounts = true;
+                    dossierContext.archive.appendToFile(dossierContext.relativePath, data, options, callback);
+                });
+            }
+        })
     };
 
 
     this.dsuLog = (message, callback) => {
-        this.appendToFile("/dsu-metadata-log", message + "\n", {ignoreMissing: true}, callback);
+        whenSafe(() => {
+            this.appendToFile("/dsu-metadata-log", message + "\n", {ignoreMissing: true}, callback);
+        })
     }
     /**
      * @param {string} fsFolderPath
@@ -794,643 +826,691 @@ function Archive(archiveConfigurator) {
     }
 
     this.addFolder = (fsFolderPath, barPath, options, callback) => {
-        const defaultOpts = {encrypt: true, ignoreMounts: false, embedded: false};
-        if (typeof options === "function") {
-            callback = options;
-            options = {};
-        }
-        callback = $$.makeSaneCallback(callback);
-        Object.assign(defaultOpts, options);
-        options = defaultOpts;
+        whenSafe(() => {
+            const defaultOpts = { encrypt: true, ignoreMounts: false, embedded: false };
+            if (typeof options === "function") {
+                callback = options;
+                options = {};
+            }
+            callback = $$.makeSaneCallback(callback);
+            Object.assign(defaultOpts, options);
+            options = defaultOpts;
 
 
-        if (options.ignoreMounts === true) {
-            _addFolder(fsFolderPath, barPath, options, callback);
-        } else {
-            this.getArchiveForPath(barPath, (err, result) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${barPath}`, err));
-                }
+            if (options.ignoreMounts === true) {
+                _addFolder(fsFolderPath, barPath, options, callback);
+            } else {
+                this.getArchiveForPath(barPath, (err, result) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${barPath}`, err));
+                    }
 
-                options.ignoreMounts = true;
-                result.archive.addFolder(fsFolderPath, result.relativePath, options, callback);
-            });
-        }
+                    options.ignoreMounts = true;
+                    result.archive.addFolder(fsFolderPath, result.relativePath, options, callback);
+                });
+            }
+            
+        })
     };
 
     this.addFile = (fsFilePath, barPath, options, callback) => {
-        const defaultOpts = {encrypt: true, ignoreMounts: false};
-        if (typeof options === "function") {
-            callback = options;
-            options = {};
-        }
+        whenSafe(() => {
+            const defaultOpts = { encrypt: true, ignoreMounts: false };
+            if (typeof options === "function") {
+                callback = options;
+                options = {};
+            }
 
-        callback = $$.makeSaneCallback(callback);
-        Object.assign(defaultOpts, options);
-        options = defaultOpts;
+            callback = $$.makeSaneCallback(callback);
+            Object.assign(defaultOpts, options);
+            options = defaultOpts;
 
-        if (options.ignoreMounts === true) {
-            _addFile(fsFilePath, barPath, options, callback);
-        } else {
-            this.getArchiveForPath(barPath, (err, result) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${barPath}`, err));
-                }
+            if (options.ignoreMounts === true) {
+                _addFile(fsFilePath, barPath, options, callback);
+            } else {
+                this.getArchiveForPath(barPath, (err, result) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${barPath}`, err));
+                    }
 
-                options.ignoreMounts = true;
-                result.archive.addFile(fsFilePath, result.relativePath, options, callback);
-            });
-        }
+                    options.ignoreMounts = true;
+                    result.archive.addFile(fsFilePath, result.relativePath, options, callback);
+                });
+            }
+        })
     };
 
     this.readFile = (fileBarPath, options, callback) => {
-        const defaultOpts = {ignoreMounts: false};
-        if (typeof options === "function") {
-            callback = options;
-            options = {};
-        }
+        whenSafe(() => {
+            const defaultOpts = { ignoreMounts: false };
+            if (typeof options === "function") {
+                callback = options;
+                options = {};
+            }
 
-        callback = $$.makeSaneCallback(callback);
-        Object.assign(defaultOpts, options);
-        options = defaultOpts;
-        if (options.ignoreMounts === true) {
-            _readFile(fileBarPath, callback);
-        } else {
-            this.getArchiveForPath(fileBarPath, (err, result) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${fileBarPath}`, err));
-                }
+            callback = $$.makeSaneCallback(callback);
+            Object.assign(defaultOpts, options);
+            options = defaultOpts;
+            if (options.ignoreMounts === true) {
+                _readFile(fileBarPath, callback);
+            } else {
+                this.getArchiveForPath(fileBarPath, (err, result) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${fileBarPath}`, err));
+                    }
 
-                options.ignoreMounts = true
-                result.archive.readFile(result.relativePath, options, callback);
-            });
-        }
+                    options.ignoreMounts = true
+                    result.archive.readFile(result.relativePath, options, callback);
+                });
+            }
+        })
     };
 
     this.createReadStream = (fileBarPath, options, callback) => {
-        const defaultOpts = {encrypt: true, ignoreMounts: false};
-        if (typeof options === "function") {
-            callback = options;
-            options = {};
-        }
+        whenSafe(() => {
+            const defaultOpts = { encrypt: true, ignoreMounts: false };
+            if (typeof options === "function") {
+                callback = options;
+                options = {};
+            }
 
-        callback = $$.makeSaneCallback(callback);
-        Object.assign(defaultOpts, options);
-        options = defaultOpts;
-        if (options.ignoreMounts === true) {
-            _createReadStream(fileBarPath, callback);
-        } else {
-            this.getArchiveForPath(fileBarPath, (err, result) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${fileBarPath}`, err));
-                }
+            callback = $$.makeSaneCallback(callback);
+            Object.assign(defaultOpts, options);
+            options = defaultOpts;
+            if (options.ignoreMounts === true) {
+                _createReadStream(fileBarPath, callback);
+            } else {
+                this.getArchiveForPath(fileBarPath, (err, result) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${fileBarPath}`, err));
+                    }
 
-                options.ignoreMounts = true;
-                result.archive.createReadStream(result.relativePath, options, callback);
-            });
-        }
+                    options.ignoreMounts = true;
+                    result.archive.createReadStream(result.relativePath, options, callback);
+                });
+            }
+        })
     };
 
     this.extractFolder = (fsFolderPath, barPath, options, callback) => {
-        const defaultOpts = {ignoreMounts: false};
-        if (typeof options === "function") {
-            callback = options;
-            options = {};
-        }
+        whenSafe(() => {
+            const defaultOpts = { ignoreMounts: false };
+            if (typeof options === "function") {
+                callback = options;
+                options = {};
+            }
 
-        callback = $$.makeSaneCallback(callback);
-        Object.assign(defaultOpts, options);
-        options = defaultOpts;
-        if (options.ignoreMounts === true) {
-            _extractFolder(fsFolderPath, barPath, callback);
-        } else {
-            this.getArchiveForPath(barPath, (err, result) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${barPath}`, err));
-                }
+            callback = $$.makeSaneCallback(callback);
+            Object.assign(defaultOpts, options);
+            options = defaultOpts;
+            if (options.ignoreMounts === true) {
+                _extractFolder(fsFolderPath, barPath, callback);
+            } else {
+                this.getArchiveForPath(barPath, (err, result) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${barPath}`, err));
+                    }
 
-                options.ignoreMounts = true;
-                result.archive.extractFolder(fsFolderPath, result.relativePath, options, callback);
-            });
-        }
+                    options.ignoreMounts = true;
+                    result.archive.extractFolder(fsFolderPath, result.relativePath, options, callback);
+                });
+            }
+        })
     };
 
     this.extractFile = (fsFilePath, barPath, options, callback) => {
-        const defaultOpts = {ignoreMounts: false};
-        if (typeof options === "function") {
-            callback = options;
-            options = {};
-        }
+        whenSafe(() => {
+            const defaultOpts = { ignoreMounts: false };
+            if (typeof options === "function") {
+                callback = options;
+                options = {};
+            }
 
-        callback = $$.makeSaneCallback(callback);
-        Object.assign(defaultOpts, options);
-        options = defaultOpts;
+            callback = $$.makeSaneCallback(callback);
+            Object.assign(defaultOpts, options);
+            options = defaultOpts;
 
-        if (options.ignoreMounts === true) {
-            _extractFile(fsFilePath, barPath, callback);
-        } else {
-            this.getArchiveForPath(barPath, (err, result) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${barPath}`, err));
-                }
+            if (options.ignoreMounts === true) {
+                _extractFile(fsFilePath, barPath, callback);
+            } else {
+                this.getArchiveForPath(barPath, (err, result) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${barPath}`, err));
+                    }
 
-                options.ignoreMounts = true;
-                result.archive.extractFile(fsFilePath, result.relativePath, options, callback);
-            });
-        }
+                    options.ignoreMounts = true;
+                    result.archive.extractFile(fsFilePath, result.relativePath, options, callback);
+                });
+            }
+        })
     };
 
     this.writeFile = (path, data, options, callback) => {
-        const defaultOpts = {encrypt: true, ignoreMounts: false};
-        if (typeof data === "function") {
-            callback = data;
-            data = undefined;
-            options = undefined;
-        }
-        if (typeof options === "function") {
-            callback = options;
-            options = {
-                encrypt: true
-            };
-        }
-        if (typeof options === "undefined") {
-            options = {
-                encrypt: true
-            };
-        }
+        whenSafe(() => {
+            const defaultOpts = { encrypt: true, ignoreMounts: false };
+            if (typeof data === "function") {
+                callback = data;
+                data = undefined;
+                options = undefined;
+            }
+            if (typeof options === "function") {
+                callback = options;
+                options = {
+                    encrypt: true
+                };
+            }
+            if (typeof options === "undefined") {
+                options = {
+                    encrypt: true
+                };
+            }
 
-        callback = $$.makeSaneCallback(callback);
+            callback = $$.makeSaneCallback(callback);
 
-        Object.assign(defaultOpts, options);
-        options = defaultOpts;
+            Object.assign(defaultOpts, options);
+            options = defaultOpts;
 
-        if (options.ignoreMounts === true) {
-            _writeFile(path, data, options, callback);
-        } else {
-            this.getArchiveForPath(path, (err, dossierContext) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${path}`, err));
-                }
-                if (dossierContext.readonly === true) {
-                    return callback(Error("Tried to write in a readonly mounted RawDossier"));
-                }
+            if (options.ignoreMounts === true) {
+                _writeFile(path, data, options, callback);
+            } else {
+                this.getArchiveForPath(path, (err, dossierContext) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${path}`, err));
+                    }
+                    if (dossierContext.readonly === true) {
+                        return callback(Error("Tried to write in a readonly mounted RawDossier"));
+                    }
 
-                options.ignoreMounts = true;
-                dossierContext.archive.writeFile(dossierContext.relativePath, data, options, callback);
-            });
-        }
+                    options.ignoreMounts = true;
+                    dossierContext.archive.writeFile(dossierContext.relativePath, data, options, callback);
+                });
+            }
+        })
     };
 
 
     this.delete = (path, options, callback) => {
-        const defaultOpts = {ignoreMounts: false, ignoreError: false};
-        if (typeof options === 'function') {
-            callback = options;
-            options = {};
-        }
-        callback = $$.makeSaneCallback(callback);
-
-        Object.assign(defaultOpts, options);
-        options = defaultOpts;
-
-        if (options.ignoreMounts) {
-            return _delete(path, err => {
-                if (!err || (err && options.ignoreError)) {
-                    return callback();
-                }
-
-                callback(err);
-            });
-        }
-
-        this.getArchiveForPath(path, (err, dossierContext) => {
-            if (err) {
-                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${path}`, err));
+        whenSafe(() => {
+            const defaultOpts = { ignoreMounts: false, ignoreError: false };
+            if (typeof options === 'function') {
+                callback = options;
+                options = {};
             }
+            callback = $$.makeSaneCallback(callback);
 
-            if (dossierContext.readonly === true) {
-                return callback(Error("Tried to delete in a readonly mounted RawDossier"));
-            }
+            Object.assign(defaultOpts, options);
+            options = defaultOpts;
 
-            options.ignoreMounts = true;
-            dossierContext.archive.delete(dossierContext.relativePath, options, callback);
-        });
-    };
-
-    this.rename = (srcPath, dstPath, options, callback) => {
-        const defaultOpts = {ignoreMounts: false};
-        if (typeof options === 'function') {
-            callback = options;
-            options = {};
-        }
-
-        callback = $$.makeSaneCallback(callback);
-        Object.assign(defaultOpts, options);
-        options = defaultOpts;
-
-        if (options.ignoreMounts) {
-            _rename(srcPath, dstPath, callback);
-            return;
-        }
-
-        this.getArchiveForPath(srcPath, (err, dossierContext) => {
-            if (err) {
-                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${srcPath}`, err));
-            }
-            if (dossierContext.readonly === true) {
-                return callback(Error("Tried to rename in a readonly mounted RawDossier"));
-            }
-
-            const relativeSrcPath = dossierContext.relativePath;
-            this.getArchiveForPath(dstPath, (err, dstDossierContext) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${dstPath}`, err));
-                }
-
-                if (dstDossierContext.prefixPath !== dossierContext.prefixPath) {
-                    return callback(Error('Destination is invalid. Renaming must be done in the scope of the same dossier'));
-                }
-
-                options.ignoreMounts = true;
-                dossierContext.archive.rename(relativeSrcPath, dstDossierContext.relativePath, options, callback);
-            })
-        });
-    };
-
-    this.listFiles = (path, options, callback) => {
-        const defaultOpts = {ignoreMounts: false, recursive: true};
-        if (typeof options === 'function') {
-            callback = options;
-            options = {};
-        }
-
-        callback = $$.makeSaneCallback(callback);
-        Object.assign(defaultOpts, options);
-        options = defaultOpts;
-        if (options.ignoreMounts === true) {
-            if (!options.recursive) {
-                return _listFiles(path, options, callback);
-            }
-
-            return _listFiles(path, options, (err, files) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to list files at path ${path}`, err));
-                }
-
-                getManifest((err, manifest) => {
-                    if (err) {
-                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to get manifest`, err));
+            if (options.ignoreMounts) {
+                return _delete(path, err => {
+                    if (!err || (err && options.ignoreError)) {
+                        return callback();
                     }
 
-                    const mountPoints = manifest.getMountPoints();
-                    if (!mountPoints.length) {
-                        return callback(undefined, files);
-                    }
-
-                    _listMountedFiles(mountPoints, (err, mountedFiles) => {
-                        if (err) {
-                            return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to list mounted files at mountPoints ${mountPoints}`, err));
-                        }
-
-                        files = files.concat(...mountedFiles);
-                        return callback(undefined, files);
-                    });
-                })
-            })
-        }
-
-        this.getArchiveForPath(path, (err, result) => {
-            if (err) {
-                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${path}`, err));
-            }
-
-            options.ignoreMounts = true;
-            result.archive.listFiles(result.relativePath, options, callback);
-        });
-    };
-
-    this.listFolders = (path, options, callback) => {
-        const defaultOpts = {ignoreMounts: false, recursive: false};
-        if (typeof options === 'function') {
-            callback = options;
-            options = {};
-        }
-
-        callback = $$.makeSaneCallback(callback);
-        Object.assign(defaultOpts, options);
-        options = defaultOpts;
-
-        if (options.ignoreMounts === true) {
-            if (!options.recursive) {
-                return _listFolders(path, options, callback);
-            }
-
-            return _listFolders(path, options, (err, folders) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to list folders at path ${path}`, err));
-                }
-
-                getManifest((err, manifest) => {
-                    if (err) {
-                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to get manifest`, err));
-                    }
-
-                    const mountPoints = manifest.getMountPoints();
-                    if (!mountPoints.length) {
-                        return callback(undefined, folders);
-                    }
-
-                    _listMountedFolders(mountPoints, (err, mountedFolders) => {
-                        if (err) {
-                            return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to list mounted folders at mountPoints ${mountPoints}`, err));
-                        }
-
-                        folders = folders.concat(...mountedFolders);
-                        return callback(undefined, folders);
-                    });
-                })
-            })
-        }
-
-        this.getArchiveForPath(path, (err, result) => {
-            if (err) {
-                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${path}`, err));
-            }
-
-            options.ignoreMounts = true;
-            result.archive.listFolders(result.relativePath, options, callback);
-        });
-    };
-
-    this.createFolder = (barPath, options, callback) => {
-        const defaultOpts = {ignoreMounts: false, encrypt: true};
-        if (typeof options === "function") {
-            callback = options;
-            options = {};
-        }
-
-        callback = $$.makeSaneCallback(callback);
-        Object.assign(defaultOpts, options);
-        options = defaultOpts;
-
-        if (options.ignoreMounts === true) {
-            _createFolder(barPath, callback);
-        } else {
-            this.getArchiveForPath(barPath, (err, dossierContext) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${barPath}`, err));
-                }
-                if (dossierContext.readonly === true) {
-                    return callback(Error("Tried to write in a readonly mounted RawDossier"));
-                }
-
-                options.ignoreMounts = true;
-                dossierContext.archive.createFolder(dossierContext.relativePath, options, callback);
-            });
-        }
-    };
-
-    this.readDir = (folderPath, options, callback) => {
-        if (typeof options === "function") {
-            callback = options;
-            options = {
-                withFileTypes: false
-            };
-        }
-
-        callback = $$.makeSaneCallback(callback);
-        const entries = {};
-        this.getArchiveForPath(folderPath, (err, result) => {
-            if (err) {
-                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${folderPath}`, err));
-            }
-
-            result.archive.listFiles(result.relativePath, {recursive: false, ignoreMounts: true}, (err, files) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to list files at path ${result.relativePath}`, err));
-                }
-
-                entries.files = files;
-
-                result.archive.listFolders(result.relativePath, {
-                    recursive: false,
-                    ignoreMounts: true
-                }, (err, folders) => {
-                    if (err) {
-                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to list folders at path ${result.relativePath}`, err));
-                    }
-
-                    if (options.withFileTypes) {
-                        entries.folders = folders;
-                    } else {
-                        entries.files = [...entries.files, ...folders];
-                    }
-                    if (result.archive === this) {
-                        getManifest(listMounts);
-                    } else {
-                        Manifest.getManifest(result.archive, listMounts);
-                    }
-
-                    function listMounts(err, handler) {
-                        if (err) {
-                            return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to list mounts`, err));
-                        }
-
-                        handler.getMountedDossiers(result.relativePath, (err, mounts) => {
-                            if (err) {
-                                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to get mounted DSUs at path ${result.relativePath}`, err));
-                            }
-                            let mountPaths = mounts.map(mount => mount.path);
-                            let folders = mountPaths.filter(mountPath => mountPath.split('/').length >= 2);
-                            folders = folders.map(mountPath => mountPath.split('/').shift());
-                            let mountedDossiers = mountPaths.filter(mountPath => mountPath.split('/').length === 1);
-                            mountedDossiers = mountedDossiers.map(mountPath => mountPath.split('/').shift());
-                            if (options.withFileTypes) {
-                                entries.mounts = mountedDossiers;
-                                entries.folders = Array.from(new Set([...entries.folders, ...folders]));
-                                entries.mounts = entries.mounts.filter(mount => entries.folders.indexOf(mount) === -1);
-                                return callback(undefined, entries);
-                            }
-                            entries.files = Array.from(new Set([...entries.files, ...mounts, ...folders]));
-                            return callback(undefined, entries.files);
-                        });
-                    }
+                    callback(err);
                 });
-            });
-        });
-    };
-
-    this.cloneFolder = (srcPath, destPath, options, callback) => {
-        const defaultOpts = {ignoreMounts: false};
-        if (typeof options === 'function') {
-            callback = options;
-            options = {};
-        }
-
-        callback = $$.makeSaneCallback(callback);
-        Object.assign(defaultOpts, options);
-        options = defaultOpts;
-
-        if (options.ignoreMounts) {
-            brickMapController.cloneFolder(srcPath, destPath, callback);
-            return;
-        }
-
-        this.getArchiveForPath(srcPath, (err, dossierContext) => {
-            if (err) {
-                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${srcPath}`, err));
-            }
-            if (dossierContext.readonly === true) {
-                return callback(Error("Tried to rename in a readonly mounted RawDossier"));
             }
 
-            this.getArchiveForPath(destPath, (err, dstDossierContext) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${dstPath}`, err));
-                }
-
-                if (dstDossierContext.prefixPath !== dossierContext.prefixPath) {
-                    return callback(Error('Destination is invalid. Renaming must be done in the scope of the same dossier'));
-                }
-
-                options.ignoreMounts = true;
-                dossierContext.archive.cloneFolder(dossierContext.relativePath, dstDossierContext.relativePath, options, callback);
-            })
-        });
-    }
-
-    this.mount = (path, archiveSSI, options, callback) => {
-        if (typeof options === "function") {
-            callback = options;
-            options = undefined;
-        }
-
-        callback = $$.makeSaneCallback(callback);
-
-        const keySSISpace = require("opendsu").loadAPI("keyssi");
-
-        if (typeof archiveSSI === "string") {
-            try {
-                archiveSSI = keySSISpace.parse(archiveSSI);
-            } catch (e) {
-                return callback(createOpenDSUErrorWrapper(`The provided archiveSSI is not a valid SSI string.`, e));
-            }
-        }
-
-        if (typeof archiveSSI === "object") {
-            try {
-                archiveSSI = archiveSSI.getIdentifier();
-            } catch (e) {
-                return callback(createOpenDSUErrorWrapper(`The provided archiveSSI is not a valid SSI instance`));
-            }
-        } else {
-            return callback(createOpenDSUErrorWrapper(`The provided archiveSSI is neither a string nor a valid SSI instance`));
-        }
-
-        function internalMount() {
-            _listFiles(path, (err, files) => {
-                if (!err && files.length > 0) {
-                    return callback(Error("Tried to mount in a non-empty folder"));
-                }
-                getManifest((err, manifestHandler) => {
-                    if (err) {
-                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to get manifest handler`, err));
-                    }
-
-                    manifestHandler.mount(path, archiveSSI, options, callback);
-                });
-            });
-        }
-
-        this.getArchiveForPath(path, (err, result) => {
-            if (err) {
-                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${path}`, err));
-            }
-            if (result.relativePath === path) {
-                internalMount()
-            } else {
-                result.archive.mount(result.relativePath, archiveSSI, options, callback)
-            }
-        });
-    };
-
-    this.unmount = (path, callback) => {
-        callback = $$.makeSaneCallback(callback);
-
-        getManifest((err, manifestHandler) => {
-            if (err) {
-                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to get manifest handler`, err));
-            }
-
-            manifestHandler.unmount(path, callback);
-        });
-    };
-
-    this.listMountedDossiers = (path, callback) => {
-        callback = $$.makeSaneCallback(callback);
-
-        this.getArchiveForPath(path, (err, result) => {
-            if (err) {
-                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${path}`, err));
-            }
-
-            if (result.archive === this) {
-                getManifest(listMounts);
-            } else {
-                Manifest.getManifest(result.archive, listMounts);
-            }
-
-            function listMounts(err, handler) {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to list mounts`, err));
-                }
-
-                handler.getMountedDossiers(result.relativePath, callback);
-            }
-        });
-    };
-
-    this.listMountedDSUs = this.listMountedDossiers;
-
-    this.hasUnanchoredChanges = () => {
-        const changesExist = mountedArchivesForBatchOperations.reduce((acc, dossierContext) => {
-            return acc || dossierContext.archive.hasUnanchoredChanges();
-        }, false);
-        return brickMapController.hasUnanchoredChanges() || changesExist;
-    };
-
-    this.getArchiveForPath = (path, callback) => {
-        callback = $$.makeSaneCallback(callback);
-
-        getManifest((err, handler) => {
-            if (err) {
-                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to get manifest handler`, err));
-            }
-
-            if (this.batchInProgress()) {
-                return getArchiveForBatchOperations(handler, path, callback);
-            }
-
-
-            handler.getArchiveForPath(path, (err, result) => {
+            this.getArchiveForPath(path, (err, dossierContext) => {
                 if (err) {
                     return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${path}`, err));
                 }
 
-
-                if (result.archive === this || (!publishAnchoringNotifications || publishOptions.ignoreMounts)) {
-                    return callback(undefined, result);
+                if (dossierContext.readonly === true) {
+                    return callback(Error("Tried to delete in a readonly mounted RawDossier"));
                 }
 
-                result.archive.enableAnchoringNotifications(publishAnchoringNotifications, publishOptions, (err) => {
+                options.ignoreMounts = true;
+                dossierContext.archive.delete(dossierContext.relativePath, options, callback);
+            });
+        })
+    };
+
+    this.rename = (srcPath, dstPath, options, callback) => {
+        whenSafe(() => {
+            const defaultOpts = { ignoreMounts: false };
+            if (typeof options === 'function') {
+                callback = options;
+                options = {};
+            }
+
+            callback = $$.makeSaneCallback(callback);
+            Object.assign(defaultOpts, options);
+            options = defaultOpts;
+
+            if (options.ignoreMounts) {
+                _rename(srcPath, dstPath, callback);
+                return;
+            }
+
+            this.getArchiveForPath(srcPath, (err, dossierContext) => {
+                if (err) {
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${srcPath}`, err));
+                }
+                if (dossierContext.readonly === true) {
+                    return callback(Error("Tried to rename in a readonly mounted RawDossier"));
+                }
+
+                const relativeSrcPath = dossierContext.relativePath;
+                this.getArchiveForPath(dstPath, (err, dstDossierContext) => {
                     if (err) {
-                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to toggle anchoring notification publishing for mount point: ${mountPoint}`, err));
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${dstPath}`, err));
                     }
 
-                    callback(undefined, result);
+                    if (dstDossierContext.prefixPath !== dossierContext.prefixPath) {
+                        return callback(Error('Destination is invalid. Renaming must be done in the scope of the same dossier'));
+                    }
+
+                    options.ignoreMounts = true;
+                    dossierContext.archive.rename(relativeSrcPath, dstDossierContext.relativePath, options, callback);
                 })
             });
-        });
+        })
+    };
+
+    this.listFiles = (path, options, callback) => {
+        whenSafe(() => {
+            const defaultOpts = { ignoreMounts: false, recursive: true };
+            if (typeof options === 'function') {
+                callback = options;
+                options = {};
+            }
+
+            callback = $$.makeSaneCallback(callback);
+            Object.assign(defaultOpts, options);
+            options = defaultOpts;
+            if (options.ignoreMounts === true) {
+                if (!options.recursive) {
+                    return _listFiles(path, options, callback);
+                }
+
+                return _listFiles(path, options, (err, files) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to list files at path ${path}`, err));
+                    }
+
+                    getManifest((err, manifest) => {
+                        if (err) {
+                            return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to get manifest`, err));
+                        }
+
+                        const mountPoints = manifest.getMountPoints();
+                        if (!mountPoints.length) {
+                            return callback(undefined, files);
+                        }
+
+                        _listMountedFiles(mountPoints, (err, mountedFiles) => {
+                            if (err) {
+                                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to list mounted files at mountPoints ${mountPoints}`, err));
+                            }
+
+                            files = files.concat(...mountedFiles);
+                            return callback(undefined, files);
+                        });
+                    })
+                })
+            }
+
+            this.getArchiveForPath(path, (err, result) => {
+                if (err) {
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${path}`, err));
+                }
+
+                options.ignoreMounts = true;
+                result.archive.listFiles(result.relativePath, options, callback);
+            });
+        })
+    };
+
+    this.listFolders = (path, options, callback) => {
+        whenSafe(() => {
+            const defaultOpts = { ignoreMounts: false, recursive: false };
+            if (typeof options === 'function') {
+                callback = options;
+                options = {};
+            }
+
+            callback = $$.makeSaneCallback(callback);
+            Object.assign(defaultOpts, options);
+            options = defaultOpts;
+
+            if (options.ignoreMounts === true) {
+                if (!options.recursive) {
+                    return _listFolders(path, options, callback);
+                }
+
+                return _listFolders(path, options, (err, folders) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to list folders at path ${path}`, err));
+                    }
+
+                    getManifest((err, manifest) => {
+                        if (err) {
+                            return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to get manifest`, err));
+                        }
+
+                        const mountPoints = manifest.getMountPoints();
+                        if (!mountPoints.length) {
+                            return callback(undefined, folders);
+                        }
+
+                        _listMountedFolders(mountPoints, (err, mountedFolders) => {
+                            if (err) {
+                                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to list mounted folders at mountPoints ${mountPoints}`, err));
+                            }
+
+                            folders = folders.concat(...mountedFolders);
+                            return callback(undefined, folders);
+                        });
+                    })
+                })
+            }
+
+            this.getArchiveForPath(path, (err, result) => {
+                if (err) {
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${path}`, err));
+                }
+
+                options.ignoreMounts = true;
+                result.archive.listFolders(result.relativePath, options, callback);
+            });
+        })
+    };
+
+    this.createFolder = (barPath, options, callback) => {
+        whenSafe(() => {
+            const defaultOpts = { ignoreMounts: false, encrypt: true };
+            if (typeof options === "function") {
+                callback = options;
+                options = {};
+            }
+
+            callback = $$.makeSaneCallback(callback);
+            Object.assign(defaultOpts, options);
+            options = defaultOpts;
+
+            if (options.ignoreMounts === true) {
+                _createFolder(barPath, callback);
+            } else {
+                this.getArchiveForPath(barPath, (err, dossierContext) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${barPath}`, err));
+                    }
+                    if (dossierContext.readonly === true) {
+                        return callback(Error("Tried to write in a readonly mounted RawDossier"));
+                    }
+
+                    options.ignoreMounts = true;
+                    dossierContext.archive.createFolder(dossierContext.relativePath, options, callback);
+                });
+            }
+        })
+    };
+
+    this.readDir = (folderPath, options, callback) => {
+        whenSafe(() => {
+            if (typeof options === "function") {
+                callback = options;
+                options = {
+                    withFileTypes: false
+                };
+            }
+
+            callback = $$.makeSaneCallback(callback);
+            const entries = {};
+            this.getArchiveForPath(folderPath, (err, result) => {
+                if (err) {
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${folderPath}`, err));
+                }
+
+                result.archive.listFiles(result.relativePath, { recursive: false, ignoreMounts: true }, (err, files) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to list files at path ${result.relativePath}`, err));
+                    }
+
+                    entries.files = files;
+
+                    result.archive.listFolders(result.relativePath, {
+                        recursive: false,
+                        ignoreMounts: true
+                    }, (err, folders) => {
+                        if (err) {
+                            return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to list folders at path ${result.relativePath}`, err));
+                        }
+
+                        if (options.withFileTypes) {
+                            entries.folders = folders;
+                        } else {
+                            entries.files = [...entries.files, ...folders];
+                        }
+                        if (result.archive === this) {
+                            getManifest(listMounts);
+                        } else {
+                            Manifest.getManifest(result.archive, listMounts);
+                        }
+
+                        function listMounts(err, handler) {
+                            if (err) {
+                                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to list mounts`, err));
+                            }
+
+                            handler.getMountedDossiers(result.relativePath, (err, mounts) => {
+                                if (err) {
+                                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to get mounted DSUs at path ${result.relativePath}`, err));
+                                }
+                                let mountPaths = mounts.map(mount => mount.path);
+                                let folders = mountPaths.filter(mountPath => mountPath.split('/').length >= 2);
+                                folders = folders.map(mountPath => mountPath.split('/').shift());
+                                let mountedDossiers = mountPaths.filter(mountPath => mountPath.split('/').length === 1);
+                                mountedDossiers = mountedDossiers.map(mountPath => mountPath.split('/').shift());
+                                if (options.withFileTypes) {
+                                    entries.mounts = mountedDossiers;
+                                    entries.folders = Array.from(new Set([...entries.folders, ...folders]));
+                                    entries.mounts = entries.mounts.filter(mount => entries.folders.indexOf(mount) === -1);
+                                    return callback(undefined, entries);
+                                }
+                                entries.files = Array.from(new Set([...entries.files, ...mounts, ...folders]));
+                                return callback(undefined, entries.files);
+                            });
+                        }
+                    });
+                });
+            });
+        })
+    };
+
+    this.cloneFolder = (srcPath, destPath, options, callback) => {
+        whenSafe(() => {
+            const defaultOpts = { ignoreMounts: false };
+            if (typeof options === 'function') {
+                callback = options;
+                options = {};
+            }
+
+            callback = $$.makeSaneCallback(callback);
+            Object.assign(defaultOpts, options);
+            options = defaultOpts;
+
+            if (options.ignoreMounts) {
+                brickMapController.cloneFolder(srcPath, destPath, callback);
+                return;
+            }
+
+            this.getArchiveForPath(srcPath, (err, dossierContext) => {
+                if (err) {
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${srcPath}`, err));
+                }
+                if (dossierContext.readonly === true) {
+                    return callback(Error("Tried to rename in a readonly mounted RawDossier"));
+                }
+
+                this.getArchiveForPath(destPath, (err, dstDossierContext) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${dstPath}`, err));
+                    }
+
+                    if (dstDossierContext.prefixPath !== dossierContext.prefixPath) {
+                        return callback(Error('Destination is invalid. Renaming must be done in the scope of the same dossier'));
+                    }
+
+                    options.ignoreMounts = true;
+                    dossierContext.archive.cloneFolder(dossierContext.relativePath, dstDossierContext.relativePath, options, callback);
+                })
+            });
+        })
+    }
+
+    this.mount = (path, archiveSSI, options, callback) => {
+        whenSafe(() => {
+            if (typeof options === "function") {
+                callback = options;
+                options = undefined;
+            }
+
+            callback = $$.makeSaneCallback(callback);
+
+            const keySSISpace = require("opendsu").loadAPI("keyssi");
+
+            if (typeof archiveSSI === "string") {
+                try {
+                    archiveSSI = keySSISpace.parse(archiveSSI);
+                } catch (e) {
+                    return callback(createOpenDSUErrorWrapper(`The provided archiveSSI is not a valid SSI string.`, e));
+                }
+            }
+
+            if (typeof archiveSSI === "object") {
+                try {
+                    archiveSSI = archiveSSI.getIdentifier();
+                } catch (e) {
+                    return callback(createOpenDSUErrorWrapper(`The provided archiveSSI is not a valid SSI instance`));
+                }
+            } else {
+                return callback(createOpenDSUErrorWrapper(`The provided archiveSSI is neither a string nor a valid SSI instance`));
+            }
+
+            function internalMount() {
+                _listFiles(path, (err, files) => {
+                    if (!err && files.length > 0) {
+                        return callback(Error("Tried to mount in a non-empty folder"));
+                    }
+                    getManifest((err, manifestHandler) => {
+                        if (err) {
+                            return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to get manifest handler`, err));
+                        }
+
+                        manifestHandler.mount(path, archiveSSI, options, callback);
+                    });
+                });
+            }
+
+            this.getArchiveForPath(path, (err, result) => {
+                if (err) {
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${path}`, err));
+                }
+                if (result.relativePath === path) {
+                    internalMount()
+                } else {
+                    result.archive.mount(result.relativePath, archiveSSI, options, callback)
+                }
+            });
+        })
+    };
+
+    this.unmount = (path, callback) => {
+        whenSafe(() => {
+            callback = $$.makeSaneCallback(callback);
+
+            getManifest((err, manifestHandler) => {
+                if (err) {
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to get manifest handler`, err));
+                }
+
+                manifestHandler.unmount(path, callback);
+            });
+        })
+    };
+
+    this.listMountedDossiers = (path, callback) => {
+        whenSafe(() => {
+            callback = $$.makeSaneCallback(callback);
+
+            this.getArchiveForPath(path, (err, result) => {
+                if (err) {
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${path}`, err));
+                }
+
+                if (result.archive === this) {
+                    getManifest(listMounts);
+                } else {
+                    Manifest.getManifest(result.archive, listMounts);
+                }
+
+                function listMounts(err, handler) {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to list mounts`, err));
+                    }
+
+                    handler.getMountedDossiers(result.relativePath, callback);
+                }
+            });
+        })
+    };
+
+    this.listMountedDSUs = this.listMountedDossiers;
+
+    this.hasUnanchoredChanges = (callback) => {
+        const detectChanges = () => {
+            const changesExist = mountedArchivesForBatchOperations.reduce((acc, dossierContext) => {
+                return acc || dossierContext.archive.hasUnanchoredChanges();
+            }, false);
+            return brickMapController.hasUnanchoredChanges() || changesExist;
+        }
+
+        if (typeof callback === 'function') {
+            return whenSafe(() => {
+                callback(undefined, detectChanges());
+            })
+        }
+        
+        // console.trace("This function behaviour changed to async. Pass a callback to obtain the result. The sync version of this method can throw an exception if called while batch anchoring is in the commit phase.");
+        return detectChanges();
+    };
+
+    this.getArchiveForPath = (path, callback) => {
+        whenSafe(() => {
+            callback = $$.makeSaneCallback(callback);
+
+            getManifest((err, handler) => {
+                if (err) {
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to get manifest handler`, err));
+                }
+
+                if (this.batchInProgress()) {
+                    return getArchiveForBatchOperations(handler, path, callback);
+                }
+
+
+                handler.getArchiveForPath(path, (err, result) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${path}`, err));
+                    }
+
+
+                    if (result.archive === this || (!publishAnchoringNotifications || publishOptions.ignoreMounts)) {
+                        return callback(undefined, result);
+                    }
+
+                    result.archive.enableAnchoringNotifications(publishAnchoringNotifications, publishOptions, (err) => {
+                        if (err) {
+                            return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to toggle anchoring notification publishing for mount point: ${mountPoint}`, err));
+                        }
+
+                        callback(undefined, result);
+                    })
+                });
+            });
+        })
     };
 
     /**
@@ -1475,41 +1555,58 @@ function Archive(archiveConfigurator) {
         if (!batchOperationsInProgress) {
             return callback(new Error("No batch operations have been scheduled"))
         }
+        
+        batchCommitInProgress = true;
+        
+        batchCommitPromise = batchCommitPromise.then(() => {
+            return new Promise((resolve) => {
+                let usesOnConflictCallback = false;
 
-        let usesOnConflictCallback = false;
-
-        const anchoringStrategy = this.getAnchoringStrategy();
-        if (!anchoringStrategy.getConflictResolutionFunction() && typeof onConflict !== 'undefined') {
-            prevConflictResolutionFunction = anchoringStrategy.getConflictResolutionFunction();
-            // Set 'onConflict' callback
-            anchoringStrategy.setConflictResolutionFunction(onConflict);
-            usesOnConflictCallback = true;
-        }
-
-        commitBatchesInMountedArchives(onConflict, (err) => {
-            if (err) {
-                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to anchor`, err));
-            }
-            this.doAnchoring((err, result) => {
-                batchOperationsInProgress = false;
-                anchoringStrategy.setDecisionFunction(prevAnchoringDecisionFn);
-                if (usesOnConflictCallback) {
-                    // Restore the 'conflictResolutionFn'
-                    anchoringStrategy.setConflictResolutionFunction(prevConflictResolutionFunction);
+                const anchoringStrategy = this.getAnchoringStrategy();
+                if (!anchoringStrategy.getConflictResolutionFunction() && typeof onConflict !== 'undefined') {
+                    prevConflictResolutionFunction = anchoringStrategy.getConflictResolutionFunction();
+                    // Set 'onConflict' callback
+                    anchoringStrategy.setConflictResolutionFunction(onConflict);
+                    usesOnConflictCallback = true;
                 }
 
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to anchor`, err));
-                }
-
-                this.refresh((err) => {
+                commitBatchesInMountedArchives(onConflict, (err) => {
                     if (err) {
-                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to reload current DSU`, err));
+                        batchCommitInProgress = false;
+                        resolve();
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to anchor`, err));
                     }
-                    callback(undefined, result);
-                })
+                    this.doAnchoring((err, result) => {
+                        anchoringStrategy.setDecisionFunction(prevAnchoringDecisionFn);
+                        if (usesOnConflictCallback) {
+                            // Restore the 'conflictResolutionFn'
+                            anchoringStrategy.setConflictResolutionFunction(prevConflictResolutionFunction);
+                        }
+
+                        if (err) {
+                            batchCommitInProgress = false;
+                            batchOperationsInProgress = false;
+                            resolve();
+                            return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to anchor`, err));
+                        }
+
+                        this.refresh((err) => {
+                            batchCommitInProgress = false;
+                            batchOperationsInProgress = false;
+                            resolve();
+
+                            if (err) {
+                                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to reload current DSU`, err));
+                            }
+                            callback(undefined, result);
+                        })
+                    });
+                });
             });
-        });
+        }).catch((e) => {
+            console.error(e);
+            console.trace("This shouldn't happen. Any errors that occured during anchoring should have been already caught.");
+        })
     };
 
     /**
@@ -1800,26 +1897,28 @@ function Archive(archiveConfigurator) {
     }
 
     this.stat = (path, callback) => {
-        callback = $$.makeSaneCallback(callback);
+        whenSafe(() => {
+            callback = $$.makeSaneCallback(callback);
 
-        this.getArchiveForPath(path, (err, res) => {
-            if (err) {
-                callback(undefined, {type: undefined})
-            }
-
-            if (res.archive === this) {
-                let stats;
-                try {
-                    stats = brickMapController.stat(path);
-                } catch (e) {
-                    return callback(undefined, {type: undefined})
+            this.getArchiveForPath(path, (err, res) => {
+                if (err) {
+                    callback(undefined, { type: undefined })
                 }
 
-                callback(undefined, stats);
-            } else {
-                res.archive.stat(res.relativePath, callback);
-            }
-        });
+                if (res.archive === this) {
+                    let stats;
+                    try {
+                        stats = brickMapController.stat(path);
+                    } catch (e) {
+                        return callback(undefined, { type: undefined })
+                    }
+
+                    callback(undefined, stats);
+                } else {
+                    res.archive.stat(res.relativePath, callback);
+                }
+            });
+        })
     };
 }
 

--- a/lib/Archive.js
+++ b/lib/Archive.js
@@ -21,8 +21,8 @@ function Archive(archiveConfigurator) {
     let brickStorageService;
     let manifestHandler;
     let batchOperationsInProgress = false;
-    let batchCommitInProgress = false;
-    let batchCommitPromise = Promise.resolve();
+    let refreshInProgress = false;
+    let refreshPromise = Promise.resolve();
     let prevAnchoringDecisionFn;
     let prevConflictResolutionFunction;
 
@@ -124,20 +124,23 @@ function Archive(archiveConfigurator) {
     }
     
     /**
-     * This function waits for a batch of operations
-     * to finish anchoring before executing the `callback`.
-     * If no anchoring is in progress, the `callback` is executed
+     * This function waits for an existing "refresh" operation to finish
+     * before executing the `callback`.
+     * If no refresh operation is in progress, the `callback` is executed
      * immediately.
      * This function is called by the public methods in order to prevent
-     * race conditions when mixing batch & non-batch anchoring operations
+     * calling methods on an uninitialized brickMapController instance
      *
      * @param {function} callback 
      */
-    const whenSafe = (callback) => {
-        if (batchCommitInProgress === false) {
+    const waitIfDSUIsRefreshing = (callback) => {
+        if (refreshInProgress === false) {
             return callback();
         }
         
+        refreshPromise.then(() => {
+            callback();
+        })
     }
     
     const getArchiveForBatchOperations = (manifestHandler, path, callback) => {
@@ -216,24 +219,39 @@ function Archive(archiveConfigurator) {
      * @param {callback} callback
      */
     this.refresh = (callback) => {
-        this.load((err) => {
-            if (err) {
-                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Failed to load DSU", err));
-            }
+        waitIfDSUIsRefreshing(() => {
+            refreshInProgress = true;
+            refreshPromise = refreshPromise.then(() => {
+                return new Promise((resolve) => {
+                    this.load((err) => {
+                        if (err) {
+                            refreshInProgress = false;
+                            resolve();
+                            return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Failed to load DSU", err));
+                        }
 
-            // Restore auto sync settings if the archive was refreshed
-            this.enableAnchoringNotifications(publishAnchoringNotifications, publishOptions, (err) => {
-                if (err) {
-                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to toggle anchoring notification publishing for mount point: ${mountPoint}`, err));
-                }
-                this.enableAutoSync(autoSyncStatus, autoSyncOptions, (err) => {
-                    if (err) {
-                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Failed to enable auto sync for DSU", err));
-                    }
-                    callback();
-                });
-            });
-        });
+                        // Restore auto sync settings if the archive was refreshed
+                        this.enableAnchoringNotifications(publishAnchoringNotifications, publishOptions, (err) => {
+                            if (err) {
+                                refreshInProgress = false;
+                                resolve();
+                                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to toggle anchoring notification publishing for mount point: ${mountPoint}`, err));
+                            }
+                            this.enableAutoSync(autoSyncStatus, autoSyncOptions, (err) => {
+                                refreshInProgress = false;
+                                resolve();
+                                if (err) {
+                                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Failed to enable auto sync for DSU", err));
+                                }
+                                callback();
+                            });
+                        });
+                    });
+                }).catch((e) => {
+                    console.trace("This shouldn't happen. Refresh errors should have been already caught");
+                })
+            })
+        })
     }
 
     /**
@@ -274,14 +292,9 @@ function Archive(archiveConfigurator) {
      * @return {HashLinkSSI}
      */
     this.getCurrentAnchoredHashLink = (callback) => {
-        if (typeof callback === 'function') {
-            return whenSafe(() => {
-                return callback(undefined, brickMapController.getCurrentAnchoredHashLink());
-            })
-        }
-        
-        // console.trace("This function behaviour changed to async. Pass a callback to obtain the result. The sync version of this method can throw an exception if called while batch anchoring is in the commit phase.");
-        return brickMapController.getCurrentAnchoredHashLink();
+        return waitIfDSUIsRefreshing(() => {
+            return callback(undefined, brickMapController.getCurrentAnchoredHashLink());
+        })
     }
 
     /**
@@ -450,7 +463,7 @@ function Archive(archiveConfigurator) {
     };
 
     this.addFiles = (files, barPath, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             if (typeof options === "function") {
                 callback = options;
                 options = {
@@ -504,7 +517,7 @@ function Archive(archiveConfigurator) {
      * @param {callback} callback
      */
     this.appendToFile = (barPath, data, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             const defaultOpts = { encrypt: true, ignoreMounts: false };
             if (typeof options === "function") {
                 callback = options;
@@ -541,7 +554,7 @@ function Archive(archiveConfigurator) {
 
 
     this.dsuLog = (message, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             this.appendToFile("/dsu-metadata-log", message + "\n", {ignoreMissing: true}, callback);
         })
     }
@@ -826,7 +839,7 @@ function Archive(archiveConfigurator) {
     }
 
     this.addFolder = (fsFolderPath, barPath, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             const defaultOpts = { encrypt: true, ignoreMounts: false, embedded: false };
             if (typeof options === "function") {
                 callback = options;
@@ -854,7 +867,7 @@ function Archive(archiveConfigurator) {
     };
 
     this.addFile = (fsFilePath, barPath, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             const defaultOpts = { encrypt: true, ignoreMounts: false };
             if (typeof options === "function") {
                 callback = options;
@@ -881,7 +894,7 @@ function Archive(archiveConfigurator) {
     };
 
     this.readFile = (fileBarPath, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             const defaultOpts = { ignoreMounts: false };
             if (typeof options === "function") {
                 callback = options;
@@ -907,7 +920,7 @@ function Archive(archiveConfigurator) {
     };
 
     this.createReadStream = (fileBarPath, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             const defaultOpts = { encrypt: true, ignoreMounts: false };
             if (typeof options === "function") {
                 callback = options;
@@ -933,7 +946,7 @@ function Archive(archiveConfigurator) {
     };
 
     this.extractFolder = (fsFolderPath, barPath, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             const defaultOpts = { ignoreMounts: false };
             if (typeof options === "function") {
                 callback = options;
@@ -959,7 +972,7 @@ function Archive(archiveConfigurator) {
     };
 
     this.extractFile = (fsFilePath, barPath, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             const defaultOpts = { ignoreMounts: false };
             if (typeof options === "function") {
                 callback = options;
@@ -986,7 +999,7 @@ function Archive(archiveConfigurator) {
     };
 
     this.writeFile = (path, data, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             const defaultOpts = { encrypt: true, ignoreMounts: false };
             if (typeof data === "function") {
                 callback = data;
@@ -1030,7 +1043,7 @@ function Archive(archiveConfigurator) {
 
 
     this.delete = (path, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             const defaultOpts = { ignoreMounts: false, ignoreError: false };
             if (typeof options === 'function') {
                 callback = options;
@@ -1067,7 +1080,7 @@ function Archive(archiveConfigurator) {
     };
 
     this.rename = (srcPath, dstPath, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             const defaultOpts = { ignoreMounts: false };
             if (typeof options === 'function') {
                 callback = options;
@@ -1109,7 +1122,7 @@ function Archive(archiveConfigurator) {
     };
 
     this.listFiles = (path, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             const defaultOpts = { ignoreMounts: false, recursive: true };
             if (typeof options === 'function') {
                 callback = options;
@@ -1163,7 +1176,7 @@ function Archive(archiveConfigurator) {
     };
 
     this.listFolders = (path, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             const defaultOpts = { ignoreMounts: false, recursive: false };
             if (typeof options === 'function') {
                 callback = options;
@@ -1218,7 +1231,7 @@ function Archive(archiveConfigurator) {
     };
 
     this.createFolder = (barPath, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             const defaultOpts = { ignoreMounts: false, encrypt: true };
             if (typeof options === "function") {
                 callback = options;
@@ -1248,7 +1261,7 @@ function Archive(archiveConfigurator) {
     };
 
     this.readDir = (folderPath, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             if (typeof options === "function") {
                 callback = options;
                 options = {
@@ -1320,7 +1333,7 @@ function Archive(archiveConfigurator) {
     };
 
     this.cloneFolder = (srcPath, destPath, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             const defaultOpts = { ignoreMounts: false };
             if (typeof options === 'function') {
                 callback = options;
@@ -1361,7 +1374,7 @@ function Archive(archiveConfigurator) {
     }
 
     this.mount = (path, archiveSSI, options, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             if (typeof options === "function") {
                 callback = options;
                 options = undefined;
@@ -1418,7 +1431,7 @@ function Archive(archiveConfigurator) {
     };
 
     this.unmount = (path, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             callback = $$.makeSaneCallback(callback);
 
             getManifest((err, manifestHandler) => {
@@ -1432,7 +1445,7 @@ function Archive(archiveConfigurator) {
     };
 
     this.listMountedDossiers = (path, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             callback = $$.makeSaneCallback(callback);
 
             this.getArchiveForPath(path, (err, result) => {
@@ -1460,25 +1473,34 @@ function Archive(archiveConfigurator) {
     this.listMountedDSUs = this.listMountedDossiers;
 
     this.hasUnanchoredChanges = (callback) => {
-        const detectChanges = () => {
-            const changesExist = mountedArchivesForBatchOperations.reduce((acc, dossierContext) => {
-                return acc || dossierContext.archive.hasUnanchoredChanges();
-            }, false);
-            return brickMapController.hasUnanchoredChanges() || changesExist;
-        }
-
-        if (typeof callback === 'function') {
-            return whenSafe(() => {
-                callback(undefined, detectChanges());
+        const detectChangesInMountedDSU = (callback, changesExist = false, dsuIndex = 0) => {
+            if (dsuIndex >= mountedArchivesForBatchOperations.length) {
+                return callback(undefined, changesExist);
+            }
+            
+            const context = mountedArchivesForBatchOperations[dsuIndex++];
+            context.archive.hasUnanchoredChanges((err, result) => {
+                if (err) {
+                    return callback(err);
+                }
+                
+                detectChangesInMountedDSU(callback, result || changesExist, dsuIndex);
             })
         }
         
-        // console.trace("This function behaviour changed to async. Pass a callback to obtain the result. The sync version of this method can throw an exception if called while batch anchoring is in the commit phase.");
-        return detectChanges();
+        waitIfDSUIsRefreshing(() => {
+            detectChangesInMountedDSU((err, changesExist) => {
+                if (err) {
+                    return callback(err);
+                }
+                
+                callback(undefined, brickMapController.hasUnanchoredChanges() || changesExist);
+            })
+        });
     };
 
     this.getArchiveForPath = (path, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             callback = $$.makeSaneCallback(callback);
 
             getManifest((err, handler) => {
@@ -1555,58 +1577,45 @@ function Archive(archiveConfigurator) {
         if (!batchOperationsInProgress) {
             return callback(new Error("No batch operations have been scheduled"))
         }
-        
-        batchCommitInProgress = true;
-        
-        batchCommitPromise = batchCommitPromise.then(() => {
-            return new Promise((resolve) => {
-                let usesOnConflictCallback = false;
 
-                const anchoringStrategy = this.getAnchoringStrategy();
-                if (!anchoringStrategy.getConflictResolutionFunction() && typeof onConflict !== 'undefined') {
-                    prevConflictResolutionFunction = anchoringStrategy.getConflictResolutionFunction();
-                    // Set 'onConflict' callback
-                    anchoringStrategy.setConflictResolutionFunction(onConflict);
-                    usesOnConflictCallback = true;
+        let usesOnConflictCallback = false;
+
+        const anchoringStrategy = this.getAnchoringStrategy();
+        if (!anchoringStrategy.getConflictResolutionFunction() && typeof onConflict !== 'undefined') {
+            prevConflictResolutionFunction = anchoringStrategy.getConflictResolutionFunction();
+            // Set 'onConflict' callback
+            anchoringStrategy.setConflictResolutionFunction(onConflict);
+            usesOnConflictCallback = true;
+        }
+
+        commitBatchesInMountedArchives(onConflict, (err) => {
+            if (err) {
+                batchOperationsInProgress = false;
+                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to anchor`, err));
+            }
+
+            this.doAnchoring((err, result) => {
+                anchoringStrategy.setDecisionFunction(prevAnchoringDecisionFn);
+                if (usesOnConflictCallback) {
+                    // Restore the 'conflictResolutionFn'
+                    anchoringStrategy.setConflictResolutionFunction(prevConflictResolutionFunction);
                 }
 
-                commitBatchesInMountedArchives(onConflict, (err) => {
+                if (err) {
+                    batchOperationsInProgress = false;
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to anchor`, err));
+                }
+
+                this.refresh((err) => {
+                    batchOperationsInProgress = false;
+
                     if (err) {
-                        batchCommitInProgress = false;
-                        resolve();
-                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to anchor`, err));
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to reload current DSU`, err));
                     }
-                    this.doAnchoring((err, result) => {
-                        anchoringStrategy.setDecisionFunction(prevAnchoringDecisionFn);
-                        if (usesOnConflictCallback) {
-                            // Restore the 'conflictResolutionFn'
-                            anchoringStrategy.setConflictResolutionFunction(prevConflictResolutionFunction);
-                        }
-
-                        if (err) {
-                            batchCommitInProgress = false;
-                            batchOperationsInProgress = false;
-                            resolve();
-                            return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to anchor`, err));
-                        }
-
-                        this.refresh((err) => {
-                            batchCommitInProgress = false;
-                            batchOperationsInProgress = false;
-                            resolve();
-
-                            if (err) {
-                                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to reload current DSU`, err));
-                            }
-                            callback(undefined, result);
-                        })
-                    });
-                });
+                    callback(undefined, result);
+                })
             });
-        }).catch((e) => {
-            console.error(e);
-            console.trace("This shouldn't happen. Any errors that occured during anchoring should have been already caught.");
-        })
+        });
     };
 
     /**
@@ -1897,7 +1906,7 @@ function Archive(archiveConfigurator) {
     }
 
     this.stat = (path, callback) => {
-        whenSafe(() => {
+        waitIfDSUIsRefreshing(() => {
             callback = $$.makeSaneCallback(callback);
 
             this.getArchiveForPath(path, (err, res) => {


### PR DESCRIPTION
This PR fixes a race condition bug that occurs when a batch of operations are anchored.
Context:
Given a batch of operations on a dsu:

    dsu.beginBatch()
    dsu.writeFile()
    dsu.createFolder()
    dsu.commitBatch()

During the call of `dsu.commitBatch()` the dsu is refreshed after all the changes have been anchored. The refresh operation creates a small window in which the brick map is undefined and any operations executed in this window will fail.
This PR fixes the bug by detecting any refresh operations that might be in progress and causing any pending DSU operation to wait for the refresh to finish before executing

The pull request is part of a PR package. The order of merging the changes is as follows:
1. This PR
2. opendsu PR https://github.com/PrivateSky/OpenDSU/pull/29
3. tests PR https://github.com/PrivateSky/psk-smoke-testing/pull/2

The bug in question breaks the `fgt-workspace` wallet
![imgpsh_fullsize_anim](https://user-images.githubusercontent.com/1618554/139908590-ce48c8e5-807e-4eb2-b1f3-f5def3bdc195.png)
