### PR TITLE
Fix brickMapController race condition

### DIFF
--- a/lib/Archive.js
+++ b/lib/Archive.js
@@ -73,9 +73,19 @@ function Archive(archiveConfigurator) {
 
             brickDataExtractorCallback: (brickMeta, brick, callback) => {
                 brick.setTemplateKeySSI(keySSI);
-                const brickEncryptionKeySSI = brickMapController.getBrickEncryptionKeySSI(brickMeta);
-                brick.setKeySSI(brickEncryptionKeySSI);
-                brick.getRawData(callback);
+                
+                function extractData() {
+                    const brickEncryptionKeySSI = brickMapController.getBrickEncryptionKeySSI(brickMeta);
+                    brick.setKeySSI(brickEncryptionKeySSI);
+                    brick.getRawData(callback);
+                }
+
+                if (refreshInProgress) {
+                    return waitIfDSUIsRefreshing(() => {
+                        extractData();
+                    })
+                }
+                extractData();
             },
 
             fsAdapter: archiveConfigurator.getFsAdapter()
@@ -226,24 +236,21 @@ function Archive(archiveConfigurator) {
                     this.load((err) => {
                         if (err) {
                             refreshInProgress = false;
-                            resolve();
-                            return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Failed to load DSU", err));
+                            return resolve(OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Failed to load DSU", err)));
                         }
 
                         // Restore auto sync settings if the archive was refreshed
                         this.enableAnchoringNotifications(publishAnchoringNotifications, publishOptions, (err) => {
                             if (err) {
                                 refreshInProgress = false;
-                                resolve();
-                                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to toggle anchoring notification publishing for mount point: ${mountPoint}`, err));
+                                return resolve(OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to toggle anchoring notification publishing for mount point: ${mountPoint}`, err)));
                             }
                             this.enableAutoSync(autoSyncStatus, autoSyncOptions, (err) => {
                                 refreshInProgress = false;
-                                resolve();
                                 if (err) {
-                                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Failed to enable auto sync for DSU", err));
+                                    return resolve(OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Failed to enable auto sync for DSU", err)));
                                 }
-                                callback();
+                                resolve(callback());
                             });
                         });
                     });


### PR DESCRIPTION
This PR fixes [issue #519](https://github.com/PharmaLedger-IMI/epi-workspace/issues/519)
Changes:
* wait for any pending refresh operations to complete before trying to access the brickMapController during brick data extraction
* minor refactoring