### PR TITLE
Added methods for appending BigFile

### DIFF
--- a/lib/Archive.js
+++ b/lib/Archive.js
@@ -447,7 +447,7 @@ function Archive(archiveConfigurator) {
     const _isSizeSSIValid = (sizeSSI) => {
         try {
             const keySSISpace = require("opendsu").loadAPI("keyssi");
-            sizeSSI = keySSISpace.parse(sizeSSI);
+            keySSISpace.parse(sizeSSI);
             return true;
         } catch (error) {
             return false;   

--- a/lib/Archive.js
+++ b/lib/Archive.js
@@ -387,10 +387,71 @@ function Archive(archiveConfigurator) {
     };
 
     /**
+     * @param {sizeSSI} sizeSSI
+     */
+    const _isAvailableSpaceInLastBrick = (sizeSSI) => {
+        if(typeof sizeSSI === "string") {
+            const keySSISpace = require("opendsu").loadAPI("keyssi");
+            sizeSSI = keySSISpace.parse(sizeSSI);
+        }
+        const totalSize = sizeSSI.getTotalSize();
+        const bufferSize = sizeSSI.getBufferSize();
+        return totalSize % bufferSize !== 0;
+    };
+
+    /**
+     * @param {string} barPath
+     * @param {object} newSizeSSI
+     * @param {object} brick
+     * @param {callback} callback
+     */
+    const _appendBigFileBrick = (barPath, newSizeSSI, brick, callback) => {
+        _getBigFileBricksMeta(barPath, (error, bricksMeta) => {
+            if(error) {
+                return callback(error);
+            }
+
+            if(!_isSizeSSIPresentInBricksMetaAndIsValid(bricksMeta)) {
+                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Provided path ${barPath} is not a BigFile`));
+            }
+
+            // check using the current sizeSSI if there is available space inside the last brick
+            if(_isAvailableSpaceInLastBrick(bricksMeta[0].size)) {
+                return brickMapController.updateBigFileLastBrick(barPath, newSizeSSI, brick, callback);
+            }
+            return brickMapController.appendBigFile(barPath, newSizeSSI, brick, callback);
+        });
+    };
+
+    /**
+     * @param {string} barPath
+     * @param {callback} callback
+     */
+    const _getBigFileBricksMeta = (barPath, callback) => {
+        barPath = pskPth.normalize(barPath);
+        try {
+            const bricksMeta = brickMapController.getBricksMeta(barPath);
+            callback(null, bricksMeta);
+        } catch (err) {
+            return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Failed to find any info for path " + barPath, err));
+        }
+    };
+
+    /**
      * @param {object} bricksMeta
      */
     const _isSizeSSIPresentInBricksMeta = (bricksMeta) => {
         return !!bricksMeta && !!bricksMeta[0] && !!bricksMeta[0].size;
+    }
+
+    const _isSizeSSIValid = (sizeSSI) => {
+        try {
+            const keySSISpace = require("opendsu").loadAPI("keyssi");
+            sizeSSI = keySSISpace.parse(sizeSSI);
+            return true;
+        } catch (error) {
+            return false;   
+        }
     }
 
     const _isSizeSSIPresentInBricksMetaAndIsValid = (bricksMeta) => {
@@ -398,13 +459,7 @@ function Archive(archiveConfigurator) {
             return false;
         }
 
-        try {
-            const keySSISpace = require("opendsu").loadAPI("keyssi");
-            sizeSSI = keySSISpace.parse(bricksMeta[0].size);
-            return true;
-        } catch (error) {
-            return false;   
-        }        
+        return _isSizeSSIValid(bricksMeta[0].size);
     }
 
     /**
@@ -1212,6 +1267,82 @@ function Archive(archiveConfigurator) {
         });
     }
 
+    this.appendBigFileBrick = (path, newSizeSSI, brick, options, callback) => {
+        waitIfDSUIsRefreshing(() => {
+            const defaultOpts = {ignoreMounts: false};
+            if (typeof options === "function") {
+                callback = options;
+                options = {};
+            }
+            if (typeof options === "undefined") {
+                options = {};
+            }
+
+            callback = $$.makeSaneCallback(callback);
+            if(typeof path !== "string") {
+                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Provided path for appendBigFileBrick must be a string"));
+            }
+            if(!newSizeSSI || !_isSizeSSIValid(newSizeSSI)) {
+                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Provided newSizeSSI is not a valid sizeSSI"));
+            }
+
+            Object.assign(defaultOpts, options);
+            options = defaultOpts;
+
+            if (options.ignoreMounts === true) {
+                _appendBigFileBrick(path, newSizeSSI, brick, callback);
+            } else {
+                this.getArchiveForPath(path, (err, dossierContext) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${path}`, err));
+                    }
+                    if (dossierContext.readonly === true) {
+                        return callback(Error("Tried to write in a readonly mounted RawDossier"));
+                    }
+
+                    options.ignoreMounts = true;
+                    dossierContext.archive.appendBigFileBrick(dossierContext.relativePath, newSizeSSI, brick, options, callback);
+                });
+            }
+        });
+    }
+
+    this.getBigFileBricksMeta = (path, options, callback) => {
+        waitIfDSUIsRefreshing(() => {
+            const defaultOpts = {ignoreMounts: false};
+            if (typeof options === "function") {
+                callback = options;
+                options = {};
+            }
+            if (typeof options === "undefined") {
+                options = {};
+            }
+
+            callback = $$.makeSaneCallback(callback);
+            if(typeof path !== "string") {
+                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Provided path for writeFileFromBricks must be a string"));
+            }
+
+            Object.assign(defaultOpts, options);
+            options = defaultOpts;
+
+            if (options.ignoreMounts === true) {
+                _getBigFileBricksMeta(path, callback);
+            } else {
+                this.getArchiveForPath(path, (err, dossierContext) => {
+                    if (err) {
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU instance mounted at path ${path}`, err));
+                    }
+                    if (dossierContext.readonly === true) {
+                        return callback(Error("Tried to write in a readonly mounted RawDossier"));
+                    }
+
+                    options.ignoreMounts = true;
+                    dossierContext.archive.getBigFileBricksMeta(dossierContext.relativePath, options, callback);
+                });
+            }
+        });
+    }
 
     this.delete = (path, options, callback) => {
         waitIfDSUIsRefreshing(() => {

--- a/lib/BrickMap.js
+++ b/lib/BrickMap.js
@@ -258,6 +258,14 @@ function BrickMap(header) {
                 this.createFile(path);
                 this.updateMetadata(path, 'createdAt', timestamp);
                 break;
+            case 'replaceFirstBrick':
+                this.replaceFirstBrick(path, data);
+                this.updateMetadata(path, 'updatedAt', timestamp);
+                break;
+            case 'replaceLastBrick':
+                this.replaceLastBrick(path, data);
+                this.updateMetadata(path, 'updatedAt', timestamp);
+                break;
             default:
                 throw new Error(`Unknown operation <${operation}>`);
         }

--- a/lib/BrickMapController.js
+++ b/lib/BrickMapController.js
@@ -613,6 +613,58 @@ function BrickMapController(options) {
 
     /**
      * @param {string} path
+     * @param {Array<object>} bricksData
+     * @param {callback} callback
+     */
+    this.updateBigFileLastBrick = (path, sizeSSI, brick, callback) => {
+        validator.validate('preWrite', state.getDirtyBrickMap(), 'updateBigFile', path, {
+            sizeSSI,
+            brick
+        }, (err) => {
+            if (err) {
+                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to validate updateBigFile operation`, err));
+            }
+
+            getCurrentDiffBrickMap((err, _brickMap) => {
+                if (err) {
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to retrieve current diffBrickMap`, err));
+                }
+
+                this.replaceFirstBrick(path, { size: sizeSSI });
+                this.replaceLastBrick(path, brick);
+                this.attemptAnchoring(callback);
+            })
+        })
+    }
+
+    /**
+     * @param {string} path
+     * @param {Array<object>} bricksData
+     * @param {callback} callback
+     */
+    this.appendBigFile = (path, sizeSSI, brick, callback) => {
+        validator.validate('preWrite', state.getDirtyBrickMap(), 'appendBigFile', path, {
+            sizeSSI,
+            brick
+        }, (err) => {
+            if (err) {
+                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to validate appendBigFile operation`, err));
+            }
+
+            getCurrentDiffBrickMap((err, _brickMap) => {
+                if (err) {
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to retrieve current diffBrickMap`, err));
+                }
+
+                this.replaceFirstBrick(path, { size: sizeSSI });
+                this.appendBricksToFile(path, [brick]);
+                this.attemptAnchoring(callback);
+            })
+        })
+    }
+
+    /**
+     * @param {string} path
      * @param {callback} callback
      */
     this.deleteFile = (path, callback) => {
@@ -718,6 +770,32 @@ function BrickMapController(options) {
         const dirtyBrickMap = state.getDirtyBrickMap();
         dirtyBrickMap.appendBricksToFile(path, bricks);
         state.getCurrentDiff().appendBricksToFile(path, bricks);
+    }
+
+    /**
+     * Proxy for BrickMap.replaceFirstBrick()
+     *
+     * @param {string} path
+     * @param {Array<object>} bricks
+     * @throws {Error}
+     */
+     this.replaceFirstBrickProxyHandler = (path, brick) => {
+        const dirtyBrickMap = state.getDirtyBrickMap();
+        dirtyBrickMap.replaceFirstBrick(path, brick);
+        state.getCurrentDiff().replaceFirstBrick(path, brick);
+    }
+
+    /**
+     * Proxy for BrickMap.replaceLastBrick()
+     *
+     * @param {string} path
+     * @param {Array<object>} bricks
+     * @throws {Error}
+     */
+     this.replaceLastBrickProxyHandler = (path, brick) => {
+        const dirtyBrickMap = state.getDirtyBrickMap();
+        dirtyBrickMap.replaceLastBrick(path, brick);
+        state.getCurrentDiff().replaceLastBrick(path, brick);
     }
 
     /**

--- a/lib/BrickMapDiff.js
+++ b/lib/BrickMapDiff.js
@@ -135,5 +135,21 @@ function BrickMapDiff(header) {
     this.createFile = function (path) {
         this.log('createFile', path);
     }
+
+    /**
+     * @param {string} filePath
+     * @param {object} brick
+     */
+    this.replaceFirstBrick = function (filePath, brick) {
+        this.log('replaceFirstBrick', filePath, brick);
+    }
+
+    /**
+     * @param {string} filePath
+     * @param {object} brick
+     */
+    this.replaceLastBrick = function (filePath, brick) {
+        this.log('replaceLastBrick', filePath, brick);
+    }
 }
 module.exports = BrickMapDiff;

--- a/lib/BrickMapMixin.js
+++ b/lib/BrickMapMixin.js
@@ -58,6 +58,48 @@ const BrickMapMixin = {
     },
 
     /**
+     * @param {string} filePath
+     */
+    getNodeFromPath: function (filePath) {
+        filePath = pskPath.normalize(filePath);
+        if (filePath === "") {
+            throw new Error(`File path must not be empty.`);
+        }
+
+        const filePathNode = this.createNodesFromPath(filePath);
+        // If this node was previously deleted, remove the "deletedAt" timestamp
+        if (filePathNode.metadata.deletedAt) {
+            delete filePathNode.metadata.deletedAt;
+        }
+
+        return filePathNode;
+    },
+
+    /**
+     * @param {string} filePath
+     * @param {object} brick
+     */
+    replaceFirstBrick: function (filePath, brick) {
+        const node = this.getNodeFromPath(filePath);
+        node.metadata.updatedAt = this.getTimestamp();
+        if(node.hashLinks.length > 0) {
+            node.hashLinks[0] = brick;
+        }
+    },
+
+    /**
+     * @param {string} filePath
+     * @param {object} brick
+     */
+    replaceLastBrick: function (filePath, brick) {
+        const node = this.getNodeFromPath(filePath);
+        node.metadata.updatedAt = this.getTimestamp();
+        if(node.hashLinks.length > 0) {
+            node.hashLinks[node.hashLinks.length - 1] = brick;
+        }
+    },
+
+    /**
      * @param {object} parent
      * @param {string} name
      */


### PR DESCRIPTION
**Changes**
Added methods for appending BigFile:
- appendBigFileBrick - appends content to an existing BigFile
- getBigFileBricksMeta - get the bricksMeta for a specified BigFile

These methods are necessary for appending a **BigFile** (a file in which the bricks have as the first element a **sizeSSI**).
The **sizeSSI** contains information regarding the **totalSize** of the file, as well as the **bufferSize** of each brick.
When a **BigFile** content is appended, there are two possible situations:
1. All existing bricks are "full" (each has a **byteLength** equal to the buffer size specified inside the **sizeSSI**)
- **sizeSSI** should be updated to reflect the new size
- a new brick is added to the bricks array 
2. The last brick is not "full" (the **byteLength** is less than the buffer size specified inside the **sizeSSI**)
- **sizeSSI** should be updated to reflect the new size
- the last brick is replaced with another brick in order to append the new content

To handle these situations, two new methods are created inside the **BrickMap**: **replaceFirstBrick** and **replaceLastBrick**.
I couldn't find a way to have a method like replaceBrick(index, updatedBrick), since for the logic to replace the last brick, I don't have access to the **node** outside of **BrickMapMixin** (inside the **BrickMapController**). An alternative would be to consider the **node** **hashlinks** to be the same as **bricksMeta**, but in this way I don't think the **BrickMapDiff** algorithm will work properly.